### PR TITLE
Update dependencies to fix security issue in base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ license = "MIT OR Apache-2.0"
 keywords = [ "nonce", "random" ]
 
 [dev-dependencies]
-bincode = "1.0.0-alpha5"
+bincode = "0.8"
 
 [dependencies]
 rand = "0.3"
-chrono = "0.3"
-byteorder = "1.0"
-base64 = "0.4"
-serde = "0.9"
-serde_derive = "0.9"
+chrono = "0.4"
+byteorder = "1.1"
+base64 = "0.6"
+serde = "1.0"
+serde_derive = "1.0"
 
 clippy = { version = "^0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl TextNonce {
 
         // Get the first 12 bytes from the current time
         {
-            let now = chrono::UTC::now();
+            let now = chrono::Utc::now();
             let secs: i64 = now.timestamp();
             let nsecs: u32 = now.timestamp_subsec_nanos();
 


### PR DESCRIPTION
Updating dependencies, to fix this RUSTSEC: https://github.com/RustSec/advisory-db/blob/master/crates/base64/RUSTSEC-2017-0004.toml

It would be nice if you would publish a new version on `crates.io`.