### PR TITLE
Removed unneeded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,10 @@ license = "MIT OR Apache-2.0"
 keywords = [ "nonce", "random" ]
 edition = "2018"
 
-[dev-dependencies]
-bincode = "1.2"
-
 [dependencies]
 rand = "0.7"
-chrono = "0.4"
-byteorder = "1.3"
 base64 = "0.12"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "1.0", features = [ "derive" ], optional = true }
+
+[dev-dependencies]
+bincode = "1.2"


### PR DESCRIPTION
Hi, I noticed that this crate pulled multiple dependencies that are not quite needed in modern times, as Rust stdlib has grown many of the needed features, such as being able to write bytes endian-awarely and being able to take the system time. Also, Serde seems like a nice option, but not a must feature to have, so made it optional. The way optional crates work in Cargo is that the feature is enabled if some other crate in the tree requires the crate, so if Serde is included in the build, this crate also gains the Serde-related features automatically; so it should be quite a streamlined option.