### PR TITLE
Bump base64 to 0.13; bump crate version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textnonce"
-version = "0.8.0-pre"
+version = "0.8.0"
 description = "Text based random nonce generator"
 authors = [ "Mike Dilger <mike@optcomp.nz>" ]
 readme = "README.md"
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7"
-base64 = "0.12"
+base64 = "0.13"
 serde = { version = "1.0", features = [ "derive" ], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
A version bump as suggested here: https://github.com/mikedilger/mime-multipart/pull/10#issuecomment-701924208