### PR TITLE
Update rand to 0.10.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [ "nonce", "random" ]
 edition = "2018"
 
 [dependencies]
-rand = "0.7"
+rand = "0.10"
 base64 = "0.13"
 serde = { version = "1.0", features = [ "derive" ], optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
         deprecated_in_future, unstable_features, single_use_lifetimes, unsafe_code,
         unreachable_pub, missing_docs, missing_copy_implementations)]
 
-use rand::rngs::OsRng;
-use rand::RngCore;
+use rand::rngs::SysRng;
+use rand::TryRng;
 use std::fmt;
 use std::io::Cursor;
 use std::ops::Deref;
@@ -103,7 +103,9 @@ impl TextNonce {
 
         // Get the last bytes from random data
 
-        OsRng.fill_bytes(&mut raw[12..bytelength]);
+        SysRng
+            .try_fill_bytes(&mut raw[12..bytelength])
+            .map_err(|e| format!("failed to obtain random bytes: {e}"))?;
 
         // base64 encode
         Ok(TextNonce(base64::encode_config(&raw, config)))


### PR DESCRIPTION
Rand changes:

- OsRng was renamed to SysRng in 0.10.
- SysRng only provides the fallible `try_fill_bytes` now. OsRng would previously panic, so using the fallible API and propagating it seems like an improvement.

Upstream Changelog: https://github.com/rust-random/rand/blob/master/CHANGELOG.md